### PR TITLE
Add auto rotation

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,6 +41,9 @@ module.exports.resizeBuffer = function( buffer, args, callback ) {
 				return callback( err )
 			}
 
+			// auto rotate based on orientation exif data
+			image.rotate()
+
 			// convert gifs to pngs
 			if( path.extname( args.key ).toLowerCase() === '.gif' ) {
 				image.png()


### PR DESCRIPTION
use sharps auto-rotation to correct the display of images consistently across devices based on orientation exif data

Images with orientation data can display the wrong way up in the WP admin on a desktop browser, while that may be the case tachyon can still render them the correct way up with this addition. It doesn't fix the problem in the WP admin of course so if an image is rotated there it will be the wrong way up on the sitebut the upshot here is consistency on the front end.

There are other solutions to rotation in core and patches suggested here: https://core.trac.wordpress.org/ticket/14459